### PR TITLE
Split Emerald Isnald's additional rules to separate translation strings

### DIFF
--- a/coops/emerald_island.tex
+++ b/coops/emerald_island.tex
@@ -62,19 +62,27 @@ There are unflagged Mines or Settlements left in map at the end of Round 8.
 \end{itemize}
 
 \subsection*{\MakeUppercase{Additional Rules}}
+
 \begin{itemize}
     \item You can't build a \svgunit{golden} Dwelling.
+
     \item You can give Units to another player, even outside your Turn, if one of your Heroes is:
     \begin{itemize}
         \item On the same Map Tile as another player's Hero.
         \item In another player's Town.
         \item Next to another player's Hero.
     \end{itemize}
+
     \item If you have no Units in your Unit Deck (after a battle or if you do not keep at least one Unit), return all your Units to your Faction's Unit pool (even if another player has one or more of your Units). This includes Units you've previously given to another player.
+
     \item When in another player's Town, you may Recruit or Reinforce their Units, either for them or for yourself. You need the other player's permission for it. Corresponding Dwellings or Citadel must be built to do so.
+
     \item For the last Mine/Settlement battle, add a \svgunit{golden} Neutral Unit. You have unlimited Turns for this battle. You can't use Expert Diplomacy to skip this battle!
+
     \item The first time you reach Level IV, gain your second specialty.
+
     \item When you reach Level IV, move your Token on the Level tracker to Level III.
+
     \item Additionally, no player can:
     \begin{itemize}
         \item Attack other Heroes.

--- a/translations/emerald_island.tex/cs.po
+++ b/translations/emerald_island.tex/cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG-mission-book\n"
-"POT-Creation-Date: 2024-08-22 23:44+0200\n"
+"POT-Creation-Date: 2024-10-24 19:47+0200\n"
 "PO-Revision-Date: 2024-06-29 16:10+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,11 +18,13 @@ msgstr ""
 
 #. type: multicols*
 #: coops/sentinels.tex:5 coops/titans_stronghold.tex:5
-#: coops/emerald_island.tex:5 clash/bloody_grail.tex:5 clash/the_hunt.tex:5
+#: coops/emerald_island.tex:5 clash/bloody_grail.tex:5
+#: clash/force_of_will.tex:5 clash/the_hunt.tex:5
 #: clash/dragoncurse_castle.tex:5 campaigns/inferno_devilish_plan.tex:6
 #: campaigns/inferno_steadwicks_fall.tex:5
 #: campaigns/inferno_deal_with_the_devil.tex:5 sections/what_to_play.tex:5
-#: sections/recommendations.tex:96 sections/credits.tex:10
+#: sections/recommendations.tex:73 sections/recommendations.tex:128
+#: sections/credits.tex:10
 #, no-wrap
 msgid ""
 "{2}\n"
@@ -85,7 +87,8 @@ msgstr ""
 
 #. type: multicols*
 #: coops/sentinels.tex:67 coops/titans_stronghold.tex:68
-#: coops/emerald_island.tex:58 clash/bloody_grail.tex:64 clash/the_hunt.tex:65
+#: coops/emerald_island.tex:58 clash/bloody_grail.tex:64
+#: clash/force_of_will.tex:62 clash/the_hunt.tex:65
 #: clash/dragoncurse_castle.tex:57 campaigns/inferno_devilish_plan.tex:108
 #: campaigns/inferno_steadwicks_fall.tex:124
 #: campaigns/inferno_deal_with_the_devil.tex:120
@@ -95,6 +98,20 @@ msgid ""
 "\n"
 msgstr ""
 "\\subsection*{\\MakeUppercase{Časované Události}}\n"
+"\n"
+
+#. type: multicols*
+#: coops/sentinels.tex:91 coops/emerald_island.tex:65
+#: clash/force_of_will.tex:74 clash/the_hunt.tex:72
+#: campaigns/inferno_devilish_plan.tex:148
+#: campaigns/inferno_steadwicks_fall.tex:188
+#: campaigns/inferno_deal_with_the_devil.tex:173
+#, no-wrap
+msgid ""
+"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
+"\n"
+msgstr ""
+"\\subsection*{\\MakeUppercase{Dodatečná Pravidla}}\n"
 "\n"
 
 #. type: multicols*
@@ -127,7 +144,7 @@ msgstr ""
 
 #. type: multicols*
 #: coops/titans_stronghold.tex:39 coops/emerald_island.tex:36
-#: clash/bloody_grail.tex:33 clash/the_hunt.tex:35
+#: clash/bloody_grail.tex:33 clash/force_of_will.tex:35 clash/the_hunt.tex:35
 #: clash/dragoncurse_castle.tex:38
 #, no-wrap
 msgid ""
@@ -225,7 +242,7 @@ msgstr ""
 
 #. type: multicols*
 #: coops/emerald_island.tex:32 clash/bloody_grail.tex:29
-#: clash/dragoncurse_castle.tex:34
+#: clash/force_of_will.tex:31 clash/dragoncurse_castle.tex:34
 #, no-wrap
 msgid ""
 "\\textbf{Town Buildings:} \\svgunit{bronze} Dwelling\n"
@@ -309,23 +326,91 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: coops/emerald_island.tex:84
+#: coops/emerald_island.tex:68
 #, no-wrap
 msgid ""
-"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
 "\\begin{itemize}\n"
 "    \\item You can't build a \\svgunit{golden} Dwelling.\n"
+"\n"
+msgstr ""
+"\\begin{itemize}\n"
+"    \\item Nemůžete postavit \\svgunit{golden} Obydlí.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:75
+#, no-wrap
+msgid ""
 "    \\item You can give Units to another player, even outside your Turn, if one of your Heroes is:\n"
 "    \\begin{itemize}\n"
 "        \\item On the same Map Tile as another player's Hero.\n"
 "        \\item In another player's Town.\n"
 "        \\item Next to another player's Hero.\n"
 "    \\end{itemize}\n"
+"\n"
+msgstr ""
+"    \\item Můžete předat Jednotky jinému hráči, dokonce i mimo svůj Tah, pokud je jeden z vašich Hrdinů:\n"
+"    \\begin{itemize}\n"
+"        \\item Na stejném Dílku Mapy jako Hrdina jiného hráče.\n"
+"        \\item Ve Městě jiného hráče.\n"
+"        \\item Vedle Hrdiny jiného hráče.\n"
+"    \\end{itemize}\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:77
+#, no-wrap
+msgid ""
 "    \\item If you have no Units in your Unit Deck (after a battle or if you do not keep at least one Unit), return all your Units to your Faction's Unit pool (even if another player has one or more of your Units). This includes Units you've previously given to another player.\n"
+"\n"
+msgstr ""
+"    \\item Pokud nemáte žádné Jednotky ve svém Balíčku Jednotek (po bitvě nebo pokud si neuchováte alespoň jednu Jednotku), vraťte všechny své Jednotky do Balíčku Jednotek své Frakce (i když jiný hráč má jednu nebo více vašich Jednotek). To zahrnuje i Jednotky, které jste dříve předali jinému hráči.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:79
+#, no-wrap
+msgid ""
 "    \\item When in another player's Town, you may Recruit or Reinforce their Units, either for them or for yourself. You need the other player's permission for it. Corresponding Dwellings or Citadel must be built to do so.\n"
+"\n"
+msgstr ""
+"    \\item Když jste ve Městě jiného hráče, můžete Naverbovat nebo Posílit jejich Jednotky, buď pro daného hráče nebo pro sebe. Potřebujete k tomu povolení druhého hráče, a musí k tomu být postavena odpovídající Obydlí nebo Citadela.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:81
+#, no-wrap
+msgid ""
 "    \\item For the last Mine/Settlement battle, add a \\svgunit{golden} Neutral Unit. You have unlimited Turns for this battle. You can't use Expert Diplomacy to skip this battle!\n"
+"\n"
+msgstr ""
+"    \\item Pro poslední Souboj o Důl/Osadu přidejte \\svgunit{golden} Neutrální Jednotku. Pro tento Souboj máte neomezený počet Tahů. K přeskočení tohoto Souboje nemůžete použít Pokročilou Diplomacii!\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:83
+#, no-wrap
+msgid ""
 "    \\item The first time you reach Level IV, gain your second specialty.\n"
+"\n"
+msgstr ""
+"    \\item Poprvé, když dosáhnete Úrovně IV, získáte svou druhou Kartu Zaměření.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:85
+#, no-wrap
+msgid ""
 "    \\item When you reach Level IV, move your Token on the Level tracker to Level III.\n"
+"\n"
+msgstr ""
+"    \\item Když dosáhnete Úrovně IV, přesuňte svůj Žeton na počítadle Úrovní na Úroveň III.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:92
+#, no-wrap
+msgid ""
 "    \\item Additionally, no player can:\n"
 "    \\begin{itemize}\n"
 "        \\item Attack other Heroes.\n"
@@ -334,20 +419,6 @@ msgid ""
 "\\end{itemize}\n"
 "\n"
 msgstr ""
-"\\subsection*{\\MakeUppercase{Dodatečná Pravidla}}\n"
-"\\begin{itemize}\n"
-"    \\item Nemůžete postavit \\svgunit{golden} Obydlí.\n"
-"    \\item Můžete předat Jednotky jinému hráči, dokonce i mimo svůj Tah, pokud je jeden z vašich Hrdinů:\n"
-"    \\begin{itemize}\n"
-"        \\item Na stejném Dílku Mapy jako Hrdina jiného hráče.\n"
-"        \\item Ve Městě jiného hráče.\n"
-"        \\item Vedle Hrdiny jiného hráče.\n"
-"    \\end{itemize}\n"
-"    \\item Pokud nemáte žádné Jednotky ve svém Balíčku Jednotek (po bitvě nebo pokud si neuchováte alespoň jednu Jednotku), vraťte všechny své Jednotky do Balíčku Jednotek své Frakce (i když jiný hráč má jednu nebo více vašich Jednotek). To zahrnuje i Jednotky, které jste dříve předali jinému hráči.\n"
-"    \\item Když jste ve Městě jiného hráče, můžete Naverbovat nebo Posílit jejich Jednotky, buď pro daného hráče nebo pro sebe. Potřebujete k tomu povolení druhého hráče, a musí k tomu být postavena odpovídající Obydlí nebo Citadela.\n"
-"    \\item Pro poslední Souboj o Důl/Osadu přidejte \\svgunit{golden} Neutrální Jednotku. Pro tento Souboj máte neomezený počet Tahů. K přeskočení tohoto Souboje nemůžete použít Pokročilou Diplomacii!\n"
-"    \\item Poprvé, když dosáhnete Úrovně IV, získáte svou druhou Kartu Zaměření.\n"
-"    \\item Když dosáhnete Úrovně IV, přesuňte svůj Žeton na počítadle Úrovní na Úroveň III.\n"
 "    \\item Navíc žádný hráč nemůže:\n"
 "    \\begin{itemize}\n"
 "        \\item Útočit na jiné Hrdiny.\n"
@@ -357,7 +428,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: coops/emerald_island.tex:86
+#: coops/emerald_island.tex:94
 #, no-wrap
 msgid ""
 "\\vspace{2em}\n"
@@ -365,7 +436,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:100
+#: coops/emerald_island.tex:108
 #, no-wrap
 msgid ""
 "\\begin{center}\n"

--- a/translations/emerald_island.tex/emerald_island.tex.pot
+++ b/translations/emerald_island.tex/emerald_island.tex.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-10-22 22:57+0200\n"
+"POT-Creation-Date: 2024-10-24 19:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,6 +87,18 @@ msgstr ""
 #, no-wrap
 msgid ""
 "\\subsection*{\\MakeUppercase{Timed Events}}\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/sentinels.tex:91 coops/emerald_island.tex:65
+#: clash/force_of_will.tex:74 clash/the_hunt.tex:72
+#: campaigns/inferno_devilish_plan.tex:148
+#: campaigns/inferno_steadwicks_fall.tex:188
+#: campaigns/inferno_deal_with_the_devil.tex:173
+#, no-wrap
+msgid ""
+"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
 "\n"
 msgstr ""
 
@@ -252,23 +264,71 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:84
+#: coops/emerald_island.tex:68
 #, no-wrap
 msgid ""
-"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
 "\\begin{itemize}\n"
 "    \\item You can't build a \\svgunit{golden} Dwelling.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:75
+#, no-wrap
+msgid ""
 "    \\item You can give Units to another player, even outside your Turn, if one of your Heroes is:\n"
 "    \\begin{itemize}\n"
 "        \\item On the same Map Tile as another player's Hero.\n"
 "        \\item In another player's Town.\n"
 "        \\item Next to another player's Hero.\n"
 "    \\end{itemize}\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:77
+#, no-wrap
+msgid ""
 "    \\item If you have no Units in your Unit Deck (after a battle or if you do not keep at least one Unit), return all your Units to your Faction's Unit pool (even if another player has one or more of your Units). This includes Units you've previously given to another player.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:79
+#, no-wrap
+msgid ""
 "    \\item When in another player's Town, you may Recruit or Reinforce their Units, either for them or for yourself. You need the other player's permission for it. Corresponding Dwellings or Citadel must be built to do so.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:81
+#, no-wrap
+msgid ""
 "    \\item For the last Mine/Settlement battle, add a \\svgunit{golden} Neutral Unit. You have unlimited Turns for this battle. You can't use Expert Diplomacy to skip this battle!\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:83
+#, no-wrap
+msgid ""
 "    \\item The first time you reach Level IV, gain your second specialty.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:85
+#, no-wrap
+msgid ""
 "    \\item When you reach Level IV, move your Token on the Level tracker to Level III.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:92
+#, no-wrap
+msgid ""
 "    \\item Additionally, no player can:\n"
 "    \\begin{itemize}\n"
 "        \\item Attack other Heroes.\n"
@@ -279,7 +339,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:86
+#: coops/emerald_island.tex:94
 #, no-wrap
 msgid ""
 "\\vspace{2em}\n"
@@ -287,7 +347,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:100
+#: coops/emerald_island.tex:108
 #, no-wrap
 msgid ""
 "\\begin{center}\n"

--- a/translations/emerald_island.tex/fr.po
+++ b/translations/emerald_island.tex/fr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG-mission-book\n"
-"POT-Creation-Date: 2024-08-22 23:44+0200\n"
+"POT-Creation-Date: 2024-10-24 19:47+0200\n"
 "PO-Revision-Date: 2024-06-29 16:10+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,11 +18,13 @@ msgstr ""
 
 #. type: multicols*
 #: coops/sentinels.tex:5 coops/titans_stronghold.tex:5
-#: coops/emerald_island.tex:5 clash/bloody_grail.tex:5 clash/the_hunt.tex:5
+#: coops/emerald_island.tex:5 clash/bloody_grail.tex:5
+#: clash/force_of_will.tex:5 clash/the_hunt.tex:5
 #: clash/dragoncurse_castle.tex:5 campaigns/inferno_devilish_plan.tex:6
 #: campaigns/inferno_steadwicks_fall.tex:5
 #: campaigns/inferno_deal_with_the_devil.tex:5 sections/what_to_play.tex:5
-#: sections/recommendations.tex:96 sections/credits.tex:10
+#: sections/recommendations.tex:73 sections/recommendations.tex:128
+#: sections/credits.tex:10
 #, no-wrap
 msgid ""
 "{2}\n"
@@ -77,13 +79,26 @@ msgstr ""
 
 #. type: multicols*
 #: coops/sentinels.tex:67 coops/titans_stronghold.tex:68
-#: coops/emerald_island.tex:58 clash/bloody_grail.tex:64 clash/the_hunt.tex:65
+#: coops/emerald_island.tex:58 clash/bloody_grail.tex:64
+#: clash/force_of_will.tex:62 clash/the_hunt.tex:65
 #: clash/dragoncurse_castle.tex:57 campaigns/inferno_devilish_plan.tex:108
 #: campaigns/inferno_steadwicks_fall.tex:124
 #: campaigns/inferno_deal_with_the_devil.tex:120
 #, no-wrap
 msgid ""
 "\\subsection*{\\MakeUppercase{Timed Events}}\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/sentinels.tex:91 coops/emerald_island.tex:65
+#: clash/force_of_will.tex:74 clash/the_hunt.tex:72
+#: campaigns/inferno_devilish_plan.tex:148
+#: campaigns/inferno_steadwicks_fall.tex:188
+#: campaigns/inferno_deal_with_the_devil.tex:173
+#, no-wrap
+msgid ""
+"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
 "\n"
 msgstr ""
 
@@ -109,7 +124,7 @@ msgstr ""
 
 #. type: multicols*
 #: coops/titans_stronghold.tex:39 coops/emerald_island.tex:36
-#: clash/bloody_grail.tex:33 clash/the_hunt.tex:35
+#: clash/bloody_grail.tex:33 clash/force_of_will.tex:35 clash/the_hunt.tex:35
 #: clash/dragoncurse_castle.tex:38
 #, no-wrap
 msgid ""
@@ -186,7 +201,7 @@ msgstr ""
 
 #. type: multicols*
 #: coops/emerald_island.tex:32 clash/bloody_grail.tex:29
-#: clash/dragoncurse_castle.tex:34
+#: clash/force_of_will.tex:31 clash/dragoncurse_castle.tex:34
 #, no-wrap
 msgid ""
 "\\textbf{Town Buildings:} \\svgunit{bronze} Dwelling\n"
@@ -249,23 +264,71 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:84
+#: coops/emerald_island.tex:68
 #, no-wrap
 msgid ""
-"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
 "\\begin{itemize}\n"
 "    \\item You can't build a \\svgunit{golden} Dwelling.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:75
+#, no-wrap
+msgid ""
 "    \\item You can give Units to another player, even outside your Turn, if one of your Heroes is:\n"
 "    \\begin{itemize}\n"
 "        \\item On the same Map Tile as another player's Hero.\n"
 "        \\item In another player's Town.\n"
 "        \\item Next to another player's Hero.\n"
 "    \\end{itemize}\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:77
+#, no-wrap
+msgid ""
 "    \\item If you have no Units in your Unit Deck (after a battle or if you do not keep at least one Unit), return all your Units to your Faction's Unit pool (even if another player has one or more of your Units). This includes Units you've previously given to another player.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:79
+#, no-wrap
+msgid ""
 "    \\item When in another player's Town, you may Recruit or Reinforce their Units, either for them or for yourself. You need the other player's permission for it. Corresponding Dwellings or Citadel must be built to do so.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:81
+#, no-wrap
+msgid ""
 "    \\item For the last Mine/Settlement battle, add a \\svgunit{golden} Neutral Unit. You have unlimited Turns for this battle. You can't use Expert Diplomacy to skip this battle!\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:83
+#, no-wrap
+msgid ""
 "    \\item The first time you reach Level IV, gain your second specialty.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:85
+#, no-wrap
+msgid ""
 "    \\item When you reach Level IV, move your Token on the Level tracker to Level III.\n"
+"\n"
+msgstr ""
+
+#. type: multicols*
+#: coops/emerald_island.tex:92
+#, no-wrap
+msgid ""
 "    \\item Additionally, no player can:\n"
 "    \\begin{itemize}\n"
 "        \\item Attack other Heroes.\n"
@@ -276,7 +339,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:86
+#: coops/emerald_island.tex:94
 #, no-wrap
 msgid ""
 "\\vspace{2em}\n"
@@ -284,7 +347,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:100
+#: coops/emerald_island.tex:108
 #, no-wrap
 msgid ""
 "\\begin{center}\n"

--- a/translations/emerald_island.tex/pl.po
+++ b/translations/emerald_island.tex/pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG-mission-book\n"
-"POT-Creation-Date: 2024-08-22 23:44+0200\n"
+"POT-Creation-Date: 2024-10-24 19:47+0200\n"
 "PO-Revision-Date: 2024-06-29 16:10+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -19,11 +19,13 @@ msgstr ""
 
 #. type: multicols*
 #: coops/sentinels.tex:5 coops/titans_stronghold.tex:5
-#: coops/emerald_island.tex:5 clash/bloody_grail.tex:5 clash/the_hunt.tex:5
+#: coops/emerald_island.tex:5 clash/bloody_grail.tex:5
+#: clash/force_of_will.tex:5 clash/the_hunt.tex:5
 #: clash/dragoncurse_castle.tex:5 campaigns/inferno_devilish_plan.tex:6
 #: campaigns/inferno_steadwicks_fall.tex:5
 #: campaigns/inferno_deal_with_the_devil.tex:5 sections/what_to_play.tex:5
-#: sections/recommendations.tex:96 sections/credits.tex:10
+#: sections/recommendations.tex:73 sections/recommendations.tex:128
+#: sections/credits.tex:10
 #, no-wrap
 msgid ""
 "{2}\n"
@@ -86,7 +88,8 @@ msgstr ""
 
 #. type: multicols*
 #: coops/sentinels.tex:67 coops/titans_stronghold.tex:68
-#: coops/emerald_island.tex:58 clash/bloody_grail.tex:64 clash/the_hunt.tex:65
+#: coops/emerald_island.tex:58 clash/bloody_grail.tex:64
+#: clash/force_of_will.tex:62 clash/the_hunt.tex:65
 #: clash/dragoncurse_castle.tex:57 campaigns/inferno_devilish_plan.tex:108
 #: campaigns/inferno_steadwicks_fall.tex:124
 #: campaigns/inferno_deal_with_the_devil.tex:120
@@ -96,6 +99,20 @@ msgid ""
 "\n"
 msgstr ""
 "\\subsection*{\\MakeUppercase{Wydarzenia Czasowe}}\n"
+"\n"
+
+#. type: multicols*
+#: coops/sentinels.tex:91 coops/emerald_island.tex:65
+#: clash/force_of_will.tex:74 clash/the_hunt.tex:72
+#: campaigns/inferno_devilish_plan.tex:148
+#: campaigns/inferno_steadwicks_fall.tex:188
+#: campaigns/inferno_deal_with_the_devil.tex:173
+#, no-wrap
+msgid ""
+"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
+"\n"
+msgstr ""
+"\\subsection*{\\MakeUppercase{Dodatkowe Zasady}}\n"
 "\n"
 
 #. type: multicols*
@@ -128,7 +145,7 @@ msgstr ""
 
 #. type: multicols*
 #: coops/titans_stronghold.tex:39 coops/emerald_island.tex:36
-#: clash/bloody_grail.tex:33 clash/the_hunt.tex:35
+#: clash/bloody_grail.tex:33 clash/force_of_will.tex:35 clash/the_hunt.tex:35
 #: clash/dragoncurse_castle.tex:38
 #, no-wrap
 msgid ""
@@ -226,7 +243,7 @@ msgstr ""
 
 #. type: multicols*
 #: coops/emerald_island.tex:32 clash/bloody_grail.tex:29
-#: clash/dragoncurse_castle.tex:34
+#: clash/force_of_will.tex:31 clash/dragoncurse_castle.tex:34
 #, no-wrap
 msgid ""
 "\\textbf{Town Buildings:} \\svgunit{bronze} Dwelling\n"
@@ -308,23 +325,91 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: coops/emerald_island.tex:84
+#: coops/emerald_island.tex:68
 #, no-wrap
 msgid ""
-"\\subsection*{\\MakeUppercase{Additional Rules}}\n"
 "\\begin{itemize}\n"
 "    \\item You can't build a \\svgunit{golden} Dwelling.\n"
+"\n"
+msgstr ""
+"\\begin{itemize}\n"
+"    \\item Nie możesz zbudować \\svgunit{golden} Siedliska.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:75
+#, no-wrap
+msgid ""
 "    \\item You can give Units to another player, even outside your Turn, if one of your Heroes is:\n"
 "    \\begin{itemize}\n"
 "        \\item On the same Map Tile as another player's Hero.\n"
 "        \\item In another player's Town.\n"
 "        \\item Next to another player's Hero.\n"
 "    \\end{itemize}\n"
+"\n"
+msgstr ""
+"    \\item Możesz przekazywać jednostki innemu graczowi, nawet poza swoją turą, jeśli jeden z twoich Bohaterów jest:\n"
+"    \\begin{itemize}\n"
+"        \\item Na tym samym kafelku mapy co bohater innego gracza.\n"
+"        \\item W mieście innego gracza.\n"
+"        \\item Obok bohatera innego gracza.\n"
+"    \\end{itemize}\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:77
+#, no-wrap
+msgid ""
 "    \\item If you have no Units in your Unit Deck (after a battle or if you do not keep at least one Unit), return all your Units to your Faction's Unit pool (even if another player has one or more of your Units). This includes Units you've previously given to another player.\n"
+"\n"
+msgstr ""
+"    \\item Jeśli nie masz jednostek w swojej talii jednostek (po walce lub jeśli nie zachowasz co najmniej jednej jednostki), zwróć wszystkie swoje jednostki do puli jednostek twojej frakcji (nawet jeśli inny gracz ma jedną lub więcej twoich jednostek). Obejmuje to jednostki, które wcześniej przekazałeś innemu graczowi.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:79
+#, no-wrap
+msgid ""
 "    \\item When in another player's Town, you may Recruit or Reinforce their Units, either for them or for yourself. You need the other player's permission for it. Corresponding Dwellings or Citadel must be built to do so.\n"
+"\n"
+msgstr ""
+"    \\item Będąc w mieście innego gracza, możesz rekrutować lub wzmacniać ich jednostki, albo dla nich, albo dla siebie. Potrzebujesz na to zgody innego gracza. Odpowiednie Siedliska lub Cytadela muszą być zbudowane.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:81
+#, no-wrap
+msgid ""
 "    \\item For the last Mine/Settlement battle, add a \\svgunit{golden} Neutral Unit. You have unlimited Turns for this battle. You can't use Expert Diplomacy to skip this battle!\n"
+"\n"
+msgstr ""
+"    \\item Do ostatniej walki o Kopalnię/Osadę dodaj Neutralną \\svgunit{golden} Jednostkę. Masz nieograniczoną liczbę rund na tę walkę. Nie możesz użyć Mistrzowskiej Dyplomacji, aby pominąć tę walkę!\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:83
+#, no-wrap
+msgid ""
 "    \\item The first time you reach Level IV, gain your second specialty.\n"
+"\n"
+msgstr ""
+"    \\item Przy pierwszym osiągnięciu poziomu IV, zdobądź swoją drugą specjalizację.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:85
+#, no-wrap
+msgid ""
 "    \\item When you reach Level IV, move your Token on the Level tracker to Level III.\n"
+"\n"
+msgstr ""
+"    \\item Po osiągnięciu poziomu IV, przenieś swoją kostkę na liczniku poziomów na poziom III.\n"
+"\n"
+
+#. type: multicols*
+#: coops/emerald_island.tex:92
+#, no-wrap
+msgid ""
 "    \\item Additionally, no player can:\n"
 "    \\begin{itemize}\n"
 "        \\item Attack other Heroes.\n"
@@ -333,20 +418,6 @@ msgid ""
 "\\end{itemize}\n"
 "\n"
 msgstr ""
-"\\subsection*{\\MakeUppercase{Dodatkowe Zasady}}\n"
-"\\begin{itemize}\n"
-"    \\item Nie możesz zbudować \\svgunit{golden} Siedliska.\n"
-"    \\item Możesz przekazywać Jednostki innemu graczowi, nawet poza swoją Turą, jeśli jeden z twoich Bohaterów jest:\n"
-"    \\begin{itemize}\n"
-"        \\item Na tym samym Kafelku mapy co Bohater innego gracza.\n"
-"        \\item W Mieście innego gracza.\n"
-"        \\item Obok Bohatera innego gracza.\n"
-"    \\end{itemize}\n"
-"    \\item Jeśli nie masz Jednostek w swojej talii Jednostek (po Walce lub jeśli nie zachowasz co najmniej jednej Jednostki), zwróć wszystkie swoje Jednostki do puli Jednostek twojej Frakcji (nawet jeśli inny gracz ma jedną lub więcej twoich Jednostek). Obejmuje to Jednostki, które wcześniej przekazałeś innemu graczowi.\n"
-"    \\item Będąc w Mieście innego gracza, możesz rekrutować lub wzmacniać ich Jednostki, albo dla nich, albo dla siebie. Potrzebujesz na to zgody innego gracza. Odpowiednie Siedliska lub Cytadela muszą być zbudowane.\n"
-"    \\item Do ostatniej Walki o Kopalnię/Osadę dodaj Neutralną \\svgunit{golden} Jednostkę. Masz nieograniczoną liczbę Rund na tę Walkę. Nie możesz użyć Mistrzowskiej Dyplomacji, aby pominąć tę Walkę!\n"
-"    \\item Przy pierwszym osiągnięciu Poziomu IV, zdobądź swoją drugą specjalizację.\n"
-"    \\item Po osiągnięciu Poziomu IV, przenieś swoją Lostkę na liczniku Poziomów na Poziom III.\n"
 "    \\item Dodatkowo, żaden gracz nie może:\n"
 "    \\begin{itemize}\n"
 "        \\item Atakować innych bohaterów.\n"
@@ -356,7 +427,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: coops/emerald_island.tex:86
+#: coops/emerald_island.tex:94
 #, no-wrap
 msgid ""
 "\\vspace{2em}\n"
@@ -364,7 +435,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: coops/emerald_island.tex:100
+#: coops/emerald_island.tex:108
 #, no-wrap
 msgid ""
 "\\begin{center}\n"


### PR DESCRIPTION
I'm testing if it's easier on the eyes in Weblate.