### PR TITLE
Make map setup formatting for coop scenarios consistent with official books [re-request]

### DIFF
--- a/coops/emerald_island.tex
+++ b/coops/emerald_island.tex
@@ -39,8 +39,8 @@ This Scenario is played over 8 Rounds.
 Take the following Map Tiles and arrange them as shown in the Scenario map layout ($P$ stands for the number of players):
 
 \begin{itemize}
-	\item P × Starting (I) Map Tile
-	\item 4P × Far (II--III) Map Tile
+  \item P × Starting (I) Map Tile
+  \item 4P × Far (II--III) Map Tile
 \end{itemize}
 
 \subsection*{\MakeUppercase{Victory Conditions}}
@@ -61,8 +61,8 @@ There are unflagged Mines or Settlements left in map at the end of Round 8.
 \subsection*{\MakeUppercase{Additional Rules}}
 
 \begin{itemize}
-	\item Ignore any yellow lines between Tiles I (but not between Tiles I and Tiles II--III).
-	
+  \item Ignore any yellow lines between Tiles I (but not between Tiles I and Tiles II--III).
+  
     \item You can't build a \svgunit{golden} Dwelling.
 
     \item You can give Units to another player, even outside your Turn, if one of your Heroes is:

--- a/coops/emerald_island.tex
+++ b/coops/emerald_island.tex
@@ -38,13 +38,10 @@ This Scenario is played over 8 Rounds.
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout ($P$ stands for the number of players):
 
-$\boldsymbol{P}$ \textbf{× Starting (I) Map Tile}
 \begin{itemize}
-  \item Starting Tiles of your chosen Factions.
-  \item Ignore any yellow lines between Tiles I (but not between Tiles I and Tiles II--III)
+	\item P × Starting (I) Map Tile
+	\item 4P × Far (II--III) Map Tile
 \end{itemize}
-
-$\boldsymbol{4 P}$ \textbf{× Far (II--III) Map Tile}
 
 \subsection*{\MakeUppercase{Victory Conditions}}
 
@@ -64,6 +61,8 @@ There are unflagged Mines or Settlements left in map at the end of Round 8.
 \subsection*{\MakeUppercase{Additional Rules}}
 
 \begin{itemize}
+	\item Ignore any yellow lines between Tiles I (but not between Tiles I and Tiles II--III).
+	
     \item You can't build a \svgunit{golden} Dwelling.
 
     \item You can give Units to another player, even outside your Turn, if one of your Heroes is:

--- a/coops/sentinels.tex
+++ b/coops/sentinels.tex
@@ -41,9 +41,9 @@ This Scenario is played over 12 Rounds.
 Take the following Map Tiles and arrange them as shown in the Scenario map layout:
 
 \begin{itemize}
-	\item 2 × Starting (I) Map Tile
-	\item 4 × Far (II--III) Map Tile
-	\item 4 × Near (IV--V) Map Tile with the Obelisk Field
+  \item 2 × Starting (I) Map Tile
+  \item 4 × Far (II--III) Map Tile
+  \item 4 × Near (IV--V) Map Tile with the Obelisk Field
 \end{itemize}
 
 \subsection*{\MakeUppercase{Victory Conditions}}

--- a/coops/sentinels.tex
+++ b/coops/sentinels.tex
@@ -40,17 +40,10 @@ This Scenario is played over 12 Rounds.
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout:
 
-\textbf{2 × Starting (I) Map Tile}
 \begin{itemize}
-  \item Starting Tiles of your chosen Factions
-  \item Ignore their yellow borders
-\end{itemize}
-
-\textbf{4 × Far (II--III) Map Tile}
-
-\textbf{4 × Near (IV--V) Map Tile}
-\begin{itemize}
-  \item All Near Map Tiles must have Obelisks
+	\item 2 × Starting (I) Map Tile
+	\item 4 × Far (II--III) Map Tile
+	\item 4 × Near (IV--V) Map Tile with the Obelisk field
 \end{itemize}
 
 \subsection*{\MakeUppercase{Victory Conditions}}
@@ -90,6 +83,7 @@ One of your Towns is captured, or a Main Hero is defeated in a battle (retreat d
 \subsection*{\MakeUppercase{Additional Rules}}
 
 \begin{itemize}
+  \item Ignore all yellow borders on Starting Tiles.
   \item Players can trade resources when one of the active player's Heroes Visits a trading post or stands on a Field adjacent to an allied Hero.
   \item The Hero who defeats an enemy army gains 2 \svg{experience}.
     The victorious player rolls two Treasure Dice and resolves one of them.

--- a/coops/sentinels.tex
+++ b/coops/sentinels.tex
@@ -43,7 +43,7 @@ Take the following Map Tiles and arrange them as shown in the Scenario map layou
 \begin{itemize}
 	\item 2 × Starting (I) Map Tile
 	\item 4 × Far (II--III) Map Tile
-	\item 4 × Near (IV--V) Map Tile with the Obelisk field
+	\item 4 × Near (IV--V) Map Tile with the Obelisk Field
 \end{itemize}
 
 \subsection*{\MakeUppercase{Victory Conditions}}

--- a/coops/sentinels.tex
+++ b/coops/sentinels.tex
@@ -36,6 +36,8 @@ This Scenario is played over 12 Rounds.
 
 \textbf{Additional Bonus:} Search (2) the Artifact Deck
 
+\vspace*{\fill}\columnbreak
+
 \subsection*{\MakeUppercase{Map Setup}}
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout:
@@ -111,8 +113,8 @@ One of your Towns is captured, or a Main Hero is defeated in a battle (retreat d
   \item If the Tile where an enemy is to spawn hasn't been discovered yet, flip it over and orient it as preferred.
   \item If there is a Hero on the Field where the enemy spawns, a fight starts immediately.
 
-  \item Enemy armies move at the end of every Turn, starting with the Turn they spawned.
   \item Enemy armies have 3 MPs per Round.
+  \item Enemy armies move at the end of every Turn, starting with the Turn they spawned.
   \item Enemy armies move as described in the rulebook (p.\,33), but instead of capturing, they destroy everything in their path.
     Place Black Cubes on any Field they pass through, treating those Fields as empty from that point on.
   \item If an enemy's movement could go in different directions, the players decide which way they go.

--- a/coops/titans_stronghold.tex
+++ b/coops/titans_stronghold.tex
@@ -42,20 +42,16 @@ This Scenario is played over 16 Rounds (15 on Impossible difficulty).
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout ($P$ stands for the number of players):
 
-$\boldsymbol{P}$ \textbf{× Starting (I) Map Tile}
 \begin{itemize}
-  \item Starting Tiles of your chosen Factions.
-  \item Ignore their yellow borders.
+	\item P × Starting (I) Map Tile
+	\item 2P × Far (II--III) Map Tile
+	\item 2P × Near (IV--V) Map Tile
+	\item (P + 1) × Center (VI--VII) Map Tile
 \end{itemize}
 
-$\boldsymbol{2 P}$ \textbf{× Far (II--III) Map Tile}
-
-$\boldsymbol{2 P}$ \textbf{× Near (IV--V) Map Tile}
-
-$\boldsymbol{(P + 1)}$ \textbf{× Center (VI--VII) Map Tile}
-
-If you don't have enough VI--VII Tiles, you can use another Tile near Tile I.
-The center of this Tile is the Titans' Stronghold.
+\textbf{\MakeUppercase{Note:}} If you don’t have enough VI--VII Tiles, you can
+use another Tile near I Tiles. The center of this
+Tile is the Titans’ Stronghold.
 
 \subsection*{\MakeUppercase{Victory Conditions}}
 

--- a/coops/titans_stronghold.tex
+++ b/coops/titans_stronghold.tex
@@ -43,10 +43,10 @@ This Scenario is played over 16 Rounds (15 on Impossible difficulty).
 Take the following Map Tiles and arrange them as shown in the Scenario map layout ($P$ stands for the number of players):
 
 \begin{itemize}
-	\item P × Starting (I) Map Tile
-	\item 2P × Far (II--III) Map Tile
-	\item 2P × Near (IV--V) Map Tile
-	\item (P + 1) × Center (VI--VII) Map Tile
+  \item P × Starting (I) Map Tile
+  \item 2P × Far (II--III) Map Tile
+  \item 2P × Near (IV--V) Map Tile
+  \item (P + 1) × Center (VI--VII) Map Tile
 \end{itemize}
 
 \textbf{\MakeUppercase{Note:}} If you don’t have enough VI--VII Tiles, you can

--- a/coops/titans_stronghold.tex
+++ b/coops/titans_stronghold.tex
@@ -38,6 +38,8 @@ This Scenario is played over 16 Rounds (15 on Impossible difficulty).
 
 \textbf{Additional Bonus:} None
 
+\vspace*{\fill}\columnbreak
+
 \subsection*{\MakeUppercase{Map Setup}}
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout ($P$ stands for the number of players):

--- a/templates/default.tex
+++ b/templates/default.tex
@@ -43,10 +43,10 @@ This Scenario is played over ... Rounds.
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout:
 \begin{itemize}
-	\item W × Starting (I) Map Tile
-	\item X × Far (II--III) Map Tile
-	\item Y × Near (IV--V) Map Tile
-	\item Z × Center (VI--VII) Map Tile
+  \item W × Starting (I) Map Tile
+  \item X × Far (II--III) Map Tile
+  \item Y × Near (IV--V) Map Tile
+  \item Z × Center (VI--VII) Map Tile
 \end{itemize}
 
 \subsection*{\MakeUppercase{Victory Conditions}}

--- a/templates/default.tex
+++ b/templates/default.tex
@@ -42,15 +42,12 @@ This Scenario is played over ... Rounds.
 \subsection*{\MakeUppercase{Map Setup}}
 
 Take the following Map Tiles and arrange them as shown in the Scenario map layout:
-
-  \textbf{X × Starting (I) Map Tile}
 \begin{itemize}
-    \item ... additional constraints ...
+	\item W × Starting (I) Map Tile
+	\item X × Far (II--III) Map Tile
+	\item Y × Near (IV--V) Map Tile
+	\item Z × Center (VI--VII) Map Tile
 \end{itemize}
-
-\textbf{Y × Far (II--III) Map Tile}
-
-\textbf{Z × Near (IV--V) Map Tile}
 
 \subsection*{\MakeUppercase{Victory Conditions}}
 ...


### PR DESCRIPTION
Resolves https://github.com/qwrtln/Homm3BG-mission-book/issues/145
Changes "Map setup" section formatting for coop scenarios from "bold text with bullet points" to "just bullet points", to be consistent with how it's done in Archon Studio's official HoMM books.