### PR TITLE
Make drafts a first-class citizen in the scripts

### DIFF
--- a/tools/optimize.sh
+++ b/tools/optimize.sh
@@ -1,17 +1,46 @@
 #!/usr/bin/env bash
 
-LANGUAGE=$1
-CMYK=$2
+# Default language to 'en' if not specified
+LANGUAGE="en"
+DRAFT_MODE=false
+CMYK_MODE=false
+ARGS=""
 
-if [[ ${CMYK} == "cmyk" ]]
-then
-  ARGS=-sColorConversionStrategy=CMYK
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--drafts)
+      DRAFT_MODE=true
+      shift
+      ;;
+    --cmyk)
+      CMYK_MODE=true
+      shift
+      ;;
+    *)
+      # First non-option argument is treated as language (unless it's already set by a flag)
+      if [[ "$LANGUAGE" == "en" && "$1" != "$LANGUAGE" ]]; then
+        LANGUAGE="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ "$DRAFT_MODE" == "true" ]]; then
+  INPUT_FILE="draft-scenarios/drafts.pdf"
+  OUTPUT_FILE="draft-scenarios/drafts_optimized.pdf"
+else
+  INPUT_FILE="main_${LANGUAGE}.pdf"
+  OUTPUT_FILE="main_${LANGUAGE}_optimized.pdf"
 fi
 
+if [[ "$CMYK_MODE" == "true" ]]; then
+  ARGS="-sColorConversionStrategy=CMYK"
+fi
 
-gs -o main_${LANGUAGE}_optimized.pdf \
+gs -o "${OUTPUT_FILE}" \
   -sDEVICE=pdfwrite \
   -dCompatibilityLevel=1.5 \
   -dPDFSETTINGS=/prepress \
   -dDetectDuplicateImages=true \
-  ${ARGS} main_${LANGUAGE}.pdf
+  ${ARGS} "${INPUT_FILE}"


### PR DESCRIPTION
1. Include drafts in compare pages script:
`tools/compare_pages.sh -d -r 26-30`
2. Include monochrome mode:
`tools/compare_pages.sh -l en -r 18-19 -m`
3. Allow combining arguments in the build script:
`tools/build.sh -dm` instead of `tools/build.sh -d -m`
4. Include drafts in optimize script:
`tools/optimize.sh -d`