### PR TITLE
The ambushed accord (update).

### DIFF
--- a/draft-scenarios/coops/the_ambushed_accord.tex
+++ b/draft-scenarios/coops/the_ambushed_accord.tex
@@ -85,7 +85,7 @@ End of \textbf{\nth{13} Round:}
 \begin{itemize}
   \item Collaboratively pay $P$~×~5~\svg{gold}, $P$~×~3~\svg{building_materials} and $P$~×~\svg{valuables} to reveal the Center Map Tile ($P$ stands for the number of players), e.g., 4 players must pay 20~\svg{gold}, 12~\svg{building_materials}, and 4~\svg{valuables}.
   \item At the end of every Astrologers Round, players must decide which player gets a free \svg{morale_positive}.
-  \item Players may exchange Artifacts and Spells from their hands, as well as Units and Resources, if their Main Heroes are standing on adjacent Fields or if both Heroes are in their own Towns or on an obelisk.
+  \item Players may exchange Artifacts and Spells from their hands, as well as Units and Resources, if their Main Heroes are standing on adjacent Fields or if both Heroes are in their own Towns or on an Obelisk.
   \item Once a player defeats the Level VII Neutral Army, their Heroes are removed from the Map.
     They are no longer eligible to fight Timed Event Fights.
 \end{itemize}


### PR DESCRIPTION
<img width="2482" height="1754" alt="the_ambushed_accord-01" src="https://github.com/user-attachments/assets/da04993a-1e26-4f2a-a4b2-841effe94488" />
<img width="2482" height="1754" alt="the_ambushed_accord-02" src="https://github.com/user-attachments/assets/45d15cd9-6785-44fd-819f-61ff02f50f41" />
updated
<img width="443" height="59" alt="image" src="https://github.com/user-attachments/assets/ec3efba9-c73c-4cf2-ae4d-ded04c25941f" />
<img width="348" height="28" alt="image" src="https://github.com/user-attachments/assets/0b38fe3e-4772-4c9b-9879-901098b62dbb" />
<img width="383" height="34" alt="image" src="https://github.com/user-attachments/assets/48a49022-0f0d-4005-aaf7-cb899edaa394" />
<img width="146" height="30" alt="image" src="https://github.com/user-attachments/assets/3e043efd-3529-48b4-a39e-0e1a32e1ed65" />

